### PR TITLE
Allow variables in require data selectors

### DIFF
--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -1,59 +1,59 @@
-"use strict";
+'use strict'
 
 module.exports = {
   meta: {
     docs: {
       description:
-        "Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements",
-      category: "Possible Errors",
+        'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
+      category: 'Possible Errors',
       recommended: false,
-      url: "https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements",
+      url: 'https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
     },
     schema: [],
     messages: {
       unexpected:
-        "use data-* attribute selectors instead of classes or tag names",
+        'use data-* attribute selectors instead of classes or tag names',
     },
-    type: "suggestion",
+    type: 'suggestion',
   },
 
-  create(context) {
+  create (context) {
     return {
-      CallExpression(node) {
+      CallExpression (node) {
         if (isCallingCyGet(node) && !isDataArgument(node)) {
-          context.report({ node, messageId: "unexpected" });
+          context.report({ node, messageId: 'unexpected' })
         }
       },
-    };
+    }
   },
-};
-
-function isCallingCyGet(node) {
-  return (
-    node.callee.type === "MemberExpression" &&
-    node.callee.object.type === "Identifier" &&
-    node.callee.object.name === "cy" &&
-    node.callee.property.type === "Identifier" &&
-    node.callee.property.name === "get"
-  );
 }
 
-function isDataArgument(node) {
+function isCallingCyGet (node) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'cy' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'get'
+  )
+}
+
+function isDataArgument (node) {
   return (
     node.arguments.length > 0 &&
-    ((node.arguments[0].type === "Literal" &&
+    ((node.arguments[0].type === 'Literal' &&
       isAliasOrDataSelector(String(node.arguments[0].value))) ||
-      (node.arguments[0].type === "TemplateLiteral" &&
+      (node.arguments[0].type === 'TemplateLiteral' &&
         isAliasOrDataSelector(
-          String(node.arguments[0].quasis[0].value.cooked)
+          String(node.arguments[0].quasis[0].value.cooked),
         )) ||
-      (node.arguments[0].type === "Variable" &&
+      (node.arguments[0].type === 'Variable' &&
         isAliasOrDataSelector(String(node.arguments[0].value))))
-  );
+  )
 }
 
-function isAliasOrDataSelector(selector) {
-  return ["[data-", "@"].some(function (validValue) {
-    return selector.startsWith(validValue);
-  });
+function isAliasOrDataSelector (selector) {
+  return ['[data-', '@'].some(function (validValue) {
+    return selector.startsWith(validValue)
+  })
 }

--- a/lib/rules/require-data-selectors.js
+++ b/lib/rules/require-data-selectors.js
@@ -1,49 +1,59 @@
-'use strict'
+"use strict";
 
 module.exports = {
   meta: {
     docs: {
-      description: 'Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
-      category: 'Possible Errors',
+      description:
+        "Use data-* attributes to provide context to your selectors and insulate them from CSS or JS changes https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements",
+      category: "Possible Errors",
       recommended: false,
-      url: 'https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements',
+      url: "https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements",
     },
     schema: [],
     messages: {
-      unexpected: 'use data-* attribute selectors instead of classes or tag names',
+      unexpected:
+        "use data-* attribute selectors instead of classes or tag names",
     },
-    type: 'suggestion',
+    type: "suggestion",
   },
 
-  create (context) {
+  create(context) {
     return {
-      CallExpression (node) {
+      CallExpression(node) {
         if (isCallingCyGet(node) && !isDataArgument(node)) {
-          context.report({ node, messageId: 'unexpected' })
+          context.report({ node, messageId: "unexpected" });
         }
       },
-    }
+    };
   },
+};
+
+function isCallingCyGet(node) {
+  return (
+    node.callee.type === "MemberExpression" &&
+    node.callee.object.type === "Identifier" &&
+    node.callee.object.name === "cy" &&
+    node.callee.property.type === "Identifier" &&
+    node.callee.property.name === "get"
+  );
 }
 
-function isCallingCyGet (node) {
-  return node.callee.type === 'MemberExpression' &&
-         node.callee.object.type === 'Identifier' &&
-         node.callee.object.name === 'cy' &&
-         node.callee.property.type === 'Identifier' &&
-         node.callee.property.name === 'get'
+function isDataArgument(node) {
+  return (
+    node.arguments.length > 0 &&
+    ((node.arguments[0].type === "Literal" &&
+      isAliasOrDataSelector(String(node.arguments[0].value))) ||
+      (node.arguments[0].type === "TemplateLiteral" &&
+        isAliasOrDataSelector(
+          String(node.arguments[0].quasis[0].value.cooked)
+        )) ||
+      (node.arguments[0].type === "Variable" &&
+        isAliasOrDataSelector(String(node.arguments[0].value))))
+  );
 }
 
-function isDataArgument (node) {
-  return node.arguments.length > 0 &&
-    (
-      (node.arguments[0].type === 'Literal' && isAliasOrDataSelector(String(node.arguments[0].value))) ||
-      (node.arguments[0].type === 'TemplateLiteral' && isAliasOrDataSelector(String(node.arguments[0].quasis[0].value.cooked)))
-    )
-}
-
-function isAliasOrDataSelector (selector) {
-  return ['[data-', '@'].some(function (validValue) {
-    return selector.startsWith(validValue)
-  })
+function isAliasOrDataSelector(selector) {
+  return ["[data-", "@"].some(function (validValue) {
+    return selector.startsWith(validValue);
+  });
 }

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -10,7 +10,6 @@ const parserOptions = { ecmaVersion: 6 }
 const validVariable = `'[data-cy=submit]'`
 const invalidVariable = `'.submit'`
 
-
 ruleTester.run('require-data-selectors', rule, {
   valid: [
     { code: 'cy.get(\'[data-cy=submit]\').click()', parserOptions },

--- a/tests/lib/rules/require-data-selectors.js
+++ b/tests/lib/rules/require-data-selectors.js
@@ -7,6 +7,9 @@ const ruleTester = new RuleTester()
 
 const errors = [{ messageId: 'unexpected' }]
 const parserOptions = { ecmaVersion: 6 }
+const validVariable = `'[data-cy=submit]'`
+const invalidVariable = `'.submit'`
+
 
 ruleTester.run('require-data-selectors', rule, {
   valid: [
@@ -16,6 +19,7 @@ ruleTester.run('require-data-selectors', rule, {
     { code: 'cy.scrollTo(0, 10)', parserOptions },
     { code: 'cy.tick(500)', parserOptions },
     { code: 'cy.get(`[data-cy=${1}]`)', parserOptions },
+    { code: `cy.get(${validVariable})`, parserOptions },
     { code: 'cy.get("@my-alias")', parserOptions, errors },
     { code: 'cy.get(`@my-alias`)', parserOptions, errors },
   ],
@@ -27,5 +31,6 @@ ruleTester.run('require-data-selectors', rule, {
     { code: 'cy.get(".btn-.large").click()', parserOptions, errors },
     { code: 'cy.get(".a")', parserOptions, errors },
     { code: 'cy.get(`[daedta-cy=${1}]`)', parserOptions, errors },
+    { code: `cy.get(${invalidVariable})`, parserOptions, errors },
   ],
 })


### PR DESCRIPTION
QA engineers at my organization like to assign selectors to variables, such as 
```
const loginInput = '[data-qa="login"]'
```
Currently this violates the `require-data-selectors` rule, but I don't think it should. 

I've never written an eslint rule before, so my syntax might be wrong - but it passed the tests :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/eslint-plugin-cypress/38)
<!-- Reviewable:end -->
