### PR TITLE
Add `unsafe-to-chain-command` rule from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Note: If you installed ESLint globally then you must also install `eslint-plugin
 ```sh
 npm install eslint-plugin-cypress --save-dev
 ```
+
 or
+
 ```sh
 yarn add eslint-plugin-cypress --dev
 ```
@@ -20,9 +22,7 @@ Add an `.eslintrc.json` file to your `cypress` directory with the following:
 
 ```json
 {
-  "plugins": [
-    "cypress"
-  ]
+  "plugins": ["cypress"]
 }
 ```
 
@@ -57,9 +57,7 @@ Use the recommended configuration and you can forego configuring _plugins_, _rul
 
 ```json
 {
-  "extends": [
-    "plugin:cypress/recommended"
-  ]
+  "extends": ["plugin:cypress/recommended"]
 }
 ```
 
@@ -114,19 +112,19 @@ These rules enforce some of the [best practices recommended for using Cypress](h
 
 Rules with a check mark (✅) are enabled by default while using the `plugin:cypress/recommended` config.
 
-|    | Rule ID                                                                                  | Description                                                     |
-|:---|:-----------------------------------------------------------------------------------------|:----------------------------------------------------------------|
-| ✅ | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md)                 | Prevent assigning return values of cy calls                     |
-| ✅ | [no-unnecessary-waiting](./docs/rules/no-unnecessary-waiting.md)                         | Prevent waiting for arbitrary time periods                      |
-| ✅ | [no-async-tests](./docs/rules/no-async-tests.md)                                         | Prevent using async/await in Cypress test case                  |
-| ✅ | [unsafe-to-chain-command](./docs/rules/unsafe-to-chain-command.md)                       | Prevent chaining from unsafe to chain commands                  |
-|    | [no-force](./docs/rules/no-force.md)                                                     | Disallow using `force: true` with action commands               |
-|    | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md)               | Ensure screenshots are preceded by an assertion                 |
-|    | [require-data-selectors](./docs/rules/require-data-selectors.md)                         | Only allow data-\* attribute selectors (require-data-selectors) |
-|    | [no-pause](./docs/rules/no-pause.md)                                                     | Disallow `cy.pause()` parent command                            |
-|    | [no-single-expect-in-then-or-should](./docs/rules/no-single-expect-in-then-or-should.md) | Simplify tests by avoiding lonely expect()                      |
-|    | [no-expect-for-stub](./docs/rules/no-expect-for-stub.md)                                 | Avoid expect(stub)…                                             |
-|    | [no-useless-then-or-should](./docs/rules/no-useless-then-or-should.md)                   | Avoid `.should()` and `.then()` when only wrapping commands     |
+|     | Rule ID                                                                                  | Description                                                     |
+| :-- | :--------------------------------------------------------------------------------------- | :-------------------------------------------------------------- |
+| ✅  | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md)                 | Prevent assigning return values of cy calls                     |
+| ✅  | [no-unnecessary-waiting](./docs/rules/no-unnecessary-waiting.md)                         | Prevent waiting for arbitrary time periods                      |
+| ✅  | [no-async-tests](./docs/rules/no-async-tests.md)                                         | Prevent using async/await in Cypress test case                  |
+| ✅  | [unsafe-to-chain-command](./docs/rules/unsafe-to-chain-command.md)                       | Prevent chaining from unsafe to chain commands                  |
+|     | [no-force](./docs/rules/no-force.md)                                                     | Disallow using `force: true` with action commands               |
+|     | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md)               | Ensure screenshots are preceded by an assertion                 |
+|     | [require-data-selectors](./docs/rules/require-data-selectors.md)                         | Only allow data-\* attribute selectors (require-data-selectors) |
+|     | [no-pause](./docs/rules/no-pause.md)                                                     | Disallow `cy.pause()` parent command                            |
+|     | [no-single-expect-in-then-or-should](./docs/rules/no-single-expect-in-then-or-should.md) | Simplify tests by avoiding lonely expect()                      |
+|     | [no-expect-for-stub](./docs/rules/no-expect-for-stub.md)                                 | Avoid expect(stub)…                                             |
+|     | [no-useless-then-or-should](./docs/rules/no-useless-then-or-should.md)                   | Avoid `.should()` and `.then()` when only wrapping commands     |
 
 ## Chai and `no-unused-expressions`
 
@@ -140,10 +138,7 @@ In your `.eslintrc.json`:
 
 ```json
 {
-  "plugins": [
-    "cypress",
-    "chai-friendly"
-  ],
+  "plugins": ["cypress", "chai-friendly"],
   "rules": {
     "no-unused-expressions": 0,
     "chai-friendly/no-unused-expressions": 2
@@ -162,14 +157,15 @@ Or you can simply add its `recommended` config:
 ## Contribution Guide
 
 To add a new rule:
-  * Fork and clone this repository
-  * Install dependencies with `npm install`
-  * Generate a new rule with `npm run make-rule`
-  * Run `yarn start` or `npm start`
-  * Write test scenarios then implement logic
-  * Describe the rule in the generated `docs` file
-  * Make sure all tests are passing
-  * Add the rule to this README
-  * Create a PR
+
+- Fork and clone this repository
+- Install dependencies with `npm install`
+- Generate a new rule with `npm run make-rule`
+- Run `yarn start` or `npm start`
+- Write test scenarios then implement logic
+- Describe the rule in the generated `docs` file
+- Make sure all tests are passing
+- Add the rule to this README
+- Create a PR
 
 Use the following commit message conventions: https://github.com/semantic-release/semantic-release#commit-message-format

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Rules with a check mark (✅) are enabled by default while using the `plugin:cyp
 | ✅ | [no-assigning-return-values](./docs/rules/no-assigning-return-values.md)                 | Prevent assigning return values of cy calls                     |
 | ✅ | [no-unnecessary-waiting](./docs/rules/no-unnecessary-waiting.md)                         | Prevent waiting for arbitrary time periods                      |
 | ✅ | [no-async-tests](./docs/rules/no-async-tests.md)                                         | Prevent using async/await in Cypress test case                  |
+| ✅ | [unsafe-to-chain-command](./docs/rules/unsafe-to-chain-command.md)                       | Prevent chaining from unsafe to chain commands                  |
 |    | [no-force](./docs/rules/no-force.md)                                                     | Disallow using `force: true` with action commands               |
 |    | [assertion-before-screenshot](./docs/rules/assertion-before-screenshot.md)               | Ensure screenshots are preceded by an assertion                 |
 |    | [require-data-selectors](./docs/rules/require-data-selectors.md)                         | Only allow data-\* attribute selectors (require-data-selectors) |

--- a/docs/rules/unsafe-to-chain-command.md
+++ b/docs/rules/unsafe-to-chain-command.md
@@ -1,0 +1,3 @@
+## Unsafe to chain command
+
+See [retry-ability guide](https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle).

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -9,5 +9,6 @@ module.exports = {
     '@finsit/cypress/no-assigning-return-values': 'error',
     '@finsit/cypress/no-unnecessary-waiting': 'error',
     '@finsit/cypress/no-async-tests': 'error',
+    '@finsit/cypress/unsafe-to-chain-command': 'error',
   },
 }

--- a/lib/rules/unsafe-to-chain-command.js
+++ b/lib/rules/unsafe-to-chain-command.js
@@ -1,0 +1,89 @@
+'use strict'
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Actions should be at the end of chains, not in the middle',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle',
+    },
+    schema: [],
+    fixable: 'code',
+    messages: {
+      unexpected:
+        'It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from `cy.` in the next command.',
+    },
+  },
+  create (context) {
+    return {
+      CallExpression (node) {
+        if (
+          isRootCypress(node) &&
+          isActionUnsafeToChain(node) &&
+          node.parent.type === 'MemberExpression'
+        ) {
+          context.report({
+            node,
+            messageId: 'unexpected',
+          })
+        }
+      },
+    }
+  },
+}
+
+/** @param {import("eslint").Rule.Node} node */
+function isRootCypress (node) {
+  while (node.type === 'CallExpression') {
+    if (node.callee.type !== 'MemberExpression') {
+      return false
+    }
+
+    if (
+      node.callee.object.type === 'Identifier' &&
+      node.callee.object.name === 'cy'
+    ) {
+      return true
+    }
+
+    node = node.callee.object
+  }
+
+  return false
+}
+
+/** @param {import("eslint").Rule.Node} node */
+function isActionUnsafeToChain (node) {
+  // commands listed in the documentation with text: 'It is unsafe to chain further commands that rely on the subject after xxx'
+  const unsafeToChainActions = [
+    'blur',
+    'clear',
+    'click',
+    'check',
+    'dblclick',
+    'each',
+    'focus',
+    'rightclick',
+    'screenshot',
+    'scrollIntoView',
+    'scrollTo',
+    'select',
+    'selectFile',
+    'spread',
+    'submit',
+    'type',
+    'trigger',
+    'uncheck',
+    'within',
+  ]
+
+  return (
+    node.callee &&
+    node.callee.property &&
+    node.callee.property.type === 'Identifier' &&
+    unsafeToChainActions.includes(node.callee.property.name)
+  )
+}

--- a/tests/lib/rules/unsafe-to-chain-command.js
+++ b/tests/lib/rules/unsafe-to-chain-command.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const rule = require('../../../lib/rules/unsafe-to-chain-command')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester()
+
+const errors = [{ messageId: 'unexpected' }]
+const parserOptions = { ecmaVersion: 6 }
+
+ruleTester.run('action-ends-chain', rule, {
+  valid: [
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}"); cy.get("new-todo").type("todo B{enter}"); cy.get("new-todo").should("have.class", "active");',
+      parserOptions,
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}").should("have.class", "active");',
+      parserOptions,
+      errors,
+    },
+    {
+      code: 'cy.get("new-todo").type("todo A{enter}").type("todo B{enter}");',
+      parserOptions,
+      errors,
+    },
+  ],
+})


### PR DESCRIPTION
Added [the `unsafe-to-chain-command` rule from upstream](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/unsafe-to-chain-command.md) and added it to the recommended config. I've made a few tweaks to the original rule, really just minor code formatting and cleanup.

~I also added an autofix that I tested on a project with around 400 violations of this rule and it fixed them all correctly~. The autofix didn't actually adhere to [the recommendations in the cypress documentation](https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle). In addition, in order to support custom commands that call `get`, more complexity and config for the rule would be required, so I figured it's not worth implementing right now.

Fixes #87.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/eslint-plugin-cypress/90)
<!-- Reviewable:end -->
